### PR TITLE
Add pymysql dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ authors = [
 	{ name = 'Adam Wight' },
 ]
 dependencies = [
+	'pymysql',
 	'requests',
 ]
 license = { file = 'LICENSE' }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-requests


### PR DESCRIPTION
Library was missing from the packaging.

Removes unused `requirements.txt`.